### PR TITLE
Change input parameters of apify-get-dataset-items

### DIFF
--- a/components/apify/actions/get-dataset-items/get-dataset-items.mjs
+++ b/components/apify/actions/get-dataset-items/get-dataset-items.mjs
@@ -33,10 +33,10 @@ export default {
         "omit",
       ],
     },
-    flatten: {
+    offset: {
       propDefinition: [
         apify,
-        "flatten",
+        "offset",
       ],
     },
     limit: {
@@ -49,11 +49,10 @@ export default {
   async run({ $ }) {
     const params = {
       limit: LIMIT,
-      offset: 0,
+      offset: this.offset,
       clean: this.clean,
       fields: this.fields && this.fields.join(),
       omit: this.omit && this.omit.join(),
-      flatten: this.flatten && this.flatten.join(),
     };
 
     const results = [];

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -70,11 +70,13 @@ export default {
         const { items } = await this.listDatasets({
           offset: LIMIT * page,
           limit: LIMIT,
+          desc: true,
+          unnamed: true,
         });
         return items?.map(({
-          id: value, name: label,
+          id: value, name,
         }) => ({
-          label,
+          label: name || "unnamed",
           value,
         })) || [];
       },
@@ -126,6 +128,13 @@ export default {
       label: "Limit",
       description: "The maximum number of items to return",
       default: LIMIT,
+      optional: true,
+    },
+    offset: {
+      type: "integer",
+      label: "Offset",
+      description: "The number records to skip before returning results",
+      default: 0,
       optional: true,
     },
   },


### PR DESCRIPTION
## WHY => https://github.com/apify/integrations-team/issues/6
On top of the required changes, I tweaked the function, which gets the list of datasets. The default behaviour of an API is to return only named datasets, while users can not just insert the ID manually in PD UI. So the users are unable to retrieve items of unnamed datasets, as long as they are not connected to any previous steps of the workflow. Let me know if this change is welcome.
<img width="1456" height="1688" alt="image" src="https://github.com/user-attachments/assets/97d810a7-bb69-4727-adde-29af7da052ff" />