### PR TITLE
fix: 672 actor task sync

### DIFF
--- a/components/apify/actions/get-kvs-record/get-kvs-record.mjs
+++ b/components/apify/actions/get-kvs-record/get-kvs-record.mjs
@@ -5,7 +5,12 @@ export default {
   key: "apify-get-kvs-record",
   name: "Get Key-Value Store Record",
   description: "Gets a record from a key-value store.",
-  version: "0.0.5",
+  version: "0.0.6",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
   type: "action",
   props: {
     apify,

--- a/components/apify/actions/run-task/run-task.mjs
+++ b/components/apify/actions/run-task/run-task.mjs
@@ -6,7 +6,7 @@ import {
 export default {
   key: "apify-run-task",
   name: "Run Task",
-  description: "Run a specific task and optionally wait for it's termination.",
+  description: "Run a specific task and optionally wait for its termination.",
   version: "0.0.5",
   annotations: {
     destructiveHint: false,

--- a/components/apify/actions/run-task/run-task.mjs
+++ b/components/apify/actions/run-task/run-task.mjs
@@ -47,7 +47,7 @@ export default {
     },
     memory: {
       type: "integer",
-      label: "Memory",
+      label: "Memory (MB)",
       description: "Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the task settings.",
       optional: true,
     },

--- a/components/apify/actions/run-task/run-task.mjs
+++ b/components/apify/actions/run-task/run-task.mjs
@@ -7,7 +7,12 @@ export default {
   key: "apify-run-task",
   name: "Run Task",
   description: "Run a specific task and optionally wait for it's termination.",
-  version: "0.0.4",
+  version: "0.0.5",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
   type: "action",
   props: {
     apify,
@@ -30,13 +35,13 @@ export default {
     },
     overrideInput: {
       type: "string",
-      label: "Override Input",
-      description: "Optional JSON string to override the default input for the task run. Must be valid JSON.",
+      label: "Override Input (JSON)",
+      description: "Optional JSON object to override the task's saved input for this run. Leave empty to use the task's saved input. Must be valid JSON (e.g. `{}` for empty input).",
       optional: true,
     },
     timeout: {
       type: "integer",
-      label: "Timeout",
+      label: "Timeout (seconds)",
       description: "Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the task settings.",
       optional: true,
     },

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -267,12 +267,6 @@ export default {
       return this._client().keyValueStore(kvsId)
         .getRecordPublicUrl(recordKey);
     },
-    runTaskSynchronously({
-      taskId, params, input,
-    }) {
-      return this._client().task(taskId)
-        .call(input, params);
-    },
     setKeyValueStoreRecord({
       storeId, key, value, contentType,
     }) {

--- a/components/apify/package.json
+++ b/components/apify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/apify",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Pipedream Apify Components",
   "main": "apify.app.mjs",
   "keywords": [

--- a/components/apify_oauth/actions/get-kvs-record/get-kvs-record.mjs
+++ b/components/apify_oauth/actions/get-kvs-record/get-kvs-record.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "apify_oauth-get-kvs-record",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,


### PR DESCRIPTION
## Why
- "Run Task" and "Run Task Synchronously" were redundant; Run Task already has a "Wait for Finish" switch.
- "Run Task Synchronously" exposed fields that don't belong to `actor-task-run-sync` (Clean, Fields, Omit, Flatten, Limit) and was missing the Override Input field.
- "Override Input" didn't mention it takes JSON, and the empty/`{}` default was undocumented.
- Timeout field didn't state its unit (seconds).
- Missing the required `annotations` object (fails `pipedream/action-annotations`).

closes [672](https://github.com/apify/apify-integrations-backend/issues/672)

The connector is not yet released, so there are no users of the sync action; we can remove it outright rather than carry a deprecation path.

## What changed
**`actions/run-task/run-task.mjs`** (`0.0.4` → `0.0.5`)
- Added `annotations` (`destructiveHint: false`, `openWorldHint: true`, `readOnlyHint: false`); starting a task run mutates state and hits the Apify API.
- `overrideInput`: label `Override Input` → `Override Input (JSON)`; description now notes that empty uses the task's saved input and the value must be valid JSON (e.g. `{}`). Still optional.
- `timeout`: `Timeout` → `Timeout (seconds)`.
- Fixed pre-existing typo in component description (`it's` → `its`).

**`actions/run-task-synchronously/`** removed
- Deleted the redundant "Run Task Synchronously" action (was a 0-byte stub). Run Task + "Wait for Finish" is the single, more robust path; on Pipedream the async-start + webhook/polling flow avoids the ~300s connection limit of the `actor-task-run-sync` endpoint.
- Removed the now-orphaned `runTaskSynchronously()` method from `apify.app.mjs`.
- Bumped package `version` `0.3.1` → `0.3.2`.

**`actions/get-kvs-record/get-kvs-record.mjs`** (`0.0.5` → `0.0.6`) lint cleanup
- Added missing `annotations` (`destructiveHint: false`, `openWorldHint: true`, `readOnlyHint: true`; read-only).

## Testing
- `cd components/apify && npm run lint:fix` clean, zero errors across the package (`action-annotations` errors resolved; no new errors).
- Verified nothing else referenced the deleted action key or the removed method before deleting.
- `run-task`/`get-kvs-record` changes are prop-metadata only and `run-task` has no test file, so no unit test added.

<img width="495" height="357" alt="obrazek" src="https://github.com/user-attachments/assets/d1ac951e-0591-4816-b9e0-fcf575c12707" />
<img width="495" height="407" alt="obrazek" src="https://github.com/user-attachments/assets/78e8d287-1333-4221-9c8c-6b1eeb1642e7" />
<img width="494" height="482" alt="obrazek" src="https://github.com/user-attachments/assets/85203765-de93-4fef-aac4-6aa6d93487b5" />
<img width="494" height="428" alt="obrazek" src="https://github.com/user-attachments/assets/271bd02b-b87e-4389-b9b7-f8413142707b" />
