### PR TITLE
fix: 670 pipedream actor tagging

### DIFF
--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -7,7 +7,7 @@ export default {
   key: "apify-run-actor",
   name: "Run Actor",
   description: "Performs an execution of a selected Actor in Apify. [See the documentation](https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -300,12 +300,7 @@ export default {
     }
 
     if (buildTag) {
-      const taggedBuilds = actorDetails.taggedBuilds || {};
-      if (!taggedBuilds[buildTag]) {
-        throw new Error(
-          `Build with tag "${buildTag}" was not found for actor "${actorDetails.title || actorDetails.name}".`,
-        );
-      }
+      await apify.resolveBuildId(actorId, buildTag);
     }
 
     // Prepare input

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -1,4 +1,3 @@
-import { ACTOR_JOB_STATUSES } from "@apify/consts";
 import { LIMIT } from "./common/constants.mjs";
 import { ApifyClient } from "apify-client";
 
@@ -82,54 +81,25 @@ export default {
     buildTag: {
       type: "string",
       label: "Build",
-      description: "Actor build to run. Accepts a build tag (e.g. `latest`) or build number (e.g. `0.1.2`). Defaults to the Actor's default build.",
+      description: "Actor build to run. Pick a tag from the list or enter a build number (e.g. `0.1.2`). Defaults to the Actor's default build.",
       async options({ actorId }) {
         if (!actorId) {
           return [];
         }
 
-        const [
-          buildsResult,
-          actor,
-        ] = await Promise.all([
-          this.listBuilds({
-            actorId,
-          }),
-          this.getActor({
-            actorId,
-          }),
-        ]);
+        const { taggedBuilds = {} } = await this.getActor({
+          actorId,
+        });
 
-        const builds = buildsResult?.items ?? [];
-        const taggedBuilds = actor?.taggedBuilds ?? {};
-
-        // Map build number -> tag names pointing at it (e.g. "latest", "beta").
-        const tagsByBuildNumber = {};
-        for (const [
+        return Object.entries(taggedBuilds).map(([
           tag,
           info,
-        ] of Object.entries(taggedBuilds)) {
-          if (info?.buildNumber) {
-            tagsByBuildNumber[info.buildNumber] ??= [];
-            tagsByBuildNumber[info.buildNumber].push(tag);
-          }
-        }
-
-        // Newest first. `buildNumberInt` is returned by the REST API for reliable
-        // ordering even though the apify-client type omits it.
-        return builds
-          .filter((build) => build.status === ACTOR_JOB_STATUSES.SUCCEEDED)
-          .sort((a, b) => (b.buildNumberInt ?? 0) - (a.buildNumberInt ?? 0))
-          .map((build) => {
-            const tags = tagsByBuildNumber[build.buildNumber];
-            const tagLabel = tags?.length
-              ? ` (${tags.join(", ")})`
-              : "";
-            return {
-              label: `${build.buildNumber}${tagLabel}`,
-              value: build.buildNumber,
-            };
-          });
+        ]) => ({
+          label: info?.buildNumber
+            ? `${tag} (${info.buildNumber})`
+            : tag,
+          value: tag,
+        }));
       },
     },
     clean: {
@@ -240,8 +210,7 @@ export default {
       return this._client().actor(actorId)
         .get();
     },
-    async getBuild(actorId, buildRef) {
-      // Get actor details
+    async resolveBuildId(actorId, buildRef) {
       const actor = await this._client().actor(actorId)
         .get();
 
@@ -255,26 +224,27 @@ export default {
 
       const taggedBuilds = actor.taggedBuilds ?? {};
 
-      // Resolve by build tag (e.g. `latest`).
       if (taggedBuilds[buildRef]?.buildId) {
-        return this._client().build(taggedBuilds[buildRef].buildId)
-          .get();
+        return taggedBuilds[buildRef].buildId;
       }
 
-      // Fallback: resolve by build number (e.g. `0.1.2`) from the builds list.
       const { items: builds = [] } = await this.listBuilds({
         actorId,
       });
-      const build = builds.find(({ buildNumber }) => buildNumber === buildRef);
+      const match = builds.find(({ buildNumber }) => buildNumber === buildRef);
 
-      if (build) {
-        return this._client().build(build.id)
-          .get();
+      if (match) {
+        return match.id;
       }
 
       throw new Error(
-        `Actor ${actorId} has no build tagged or numbered "${buildRef}". Please build the actor first or pick an existing build.`,
+        `No build with tag or number "${buildRef}" found for actor ${actorId}.`,
       );
+    },
+    async getBuild(actorId, buildRef) {
+      const buildId = await this.resolveBuildId(actorId, buildRef);
+      return this._client().build(buildId)
+        .get();
     },
     listActors(opts = {}) {
       return this._client().store()

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -1,3 +1,4 @@
+import { ACTOR_JOB_STATUSES } from "@apify/consts";
 import { LIMIT } from "./common/constants.mjs";
 import { ApifyClient } from "apify-client";
 
@@ -81,15 +82,54 @@ export default {
     buildTag: {
       type: "string",
       label: "Build",
-      description: "Specifies the Actor build to run. The accepted value is the build tag. If not provided, the default build will be used.",
+      description: "Actor build to run. Accepts a build tag (e.g. `latest`) or build number (e.g. `0.1.2`). Defaults to the Actor's default build.",
       async options({ actorId }) {
-        const { taggedBuilds } = await this.getActor({
-          actorId,
-        });
+        if (!actorId) {
+          return [];
+        }
 
-        return Object.entries(taggedBuilds).map(([
-          name,
-        ]) => name);
+        const [
+          buildsResult,
+          actor,
+        ] = await Promise.all([
+          this.listBuilds({
+            actorId,
+          }),
+          this.getActor({
+            actorId,
+          }),
+        ]);
+
+        const builds = buildsResult?.items ?? [];
+        const taggedBuilds = actor?.taggedBuilds ?? {};
+
+        // Map build number -> tag names pointing at it (e.g. "latest", "beta").
+        const tagsByBuildNumber = {};
+        for (const [
+          tag,
+          info,
+        ] of Object.entries(taggedBuilds)) {
+          if (info?.buildNumber) {
+            tagsByBuildNumber[info.buildNumber] ??= [];
+            tagsByBuildNumber[info.buildNumber].push(tag);
+          }
+        }
+
+        // Newest first. `buildNumberInt` is returned by the REST API for reliable
+        // ordering even though the apify-client type omits it.
+        return builds
+          .filter((build) => build.status === ACTOR_JOB_STATUSES.SUCCEEDED)
+          .sort((a, b) => (b.buildNumberInt ?? 0) - (a.buildNumberInt ?? 0))
+          .map((build) => {
+            const tags = tagsByBuildNumber[build.buildNumber];
+            const tagLabel = tags?.length
+              ? ` (${tags.join(", ")})`
+              : "";
+            return {
+              label: `${build.buildNumber}${tagLabel}`,
+              value: build.buildNumber,
+            };
+          });
       },
     },
     clean: {

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -240,7 +240,7 @@ export default {
       return this._client().actor(actorId)
         .get();
     },
-    async getBuild(actorId, buildTag) {
+    async getBuild(actorId, buildRef) {
       // Get actor details
       const actor = await this._client().actor(actorId)
         .get();
@@ -249,20 +249,32 @@ export default {
         throw new Error(`Actor ${actorId} not found.`);
       }
 
-      if (!buildTag) {
-        buildTag = actor.defaultRunOptions.build;
+      if (!buildRef) {
+        buildRef = actor.defaultRunOptions.build;
       }
 
-      const { taggedBuilds } = actor;
+      const taggedBuilds = actor.taggedBuilds ?? {};
 
-      if (taggedBuilds[buildTag]) {
-        return this._client().build(taggedBuilds[buildTag].buildId)
+      // Resolve by build tag (e.g. `latest`).
+      if (taggedBuilds[buildRef]?.buildId) {
+        return this._client().build(taggedBuilds[buildRef].buildId)
           .get();
-      } else {
-        throw new Error(
-          `Actor ${actorId} has no build tagged "${buildTag}". Please build the actor first.`,
-        );
       }
+
+      // Fallback: resolve by build number (e.g. `0.1.2`) from the builds list.
+      const { items: builds = [] } = await this.listBuilds({
+        actorId,
+      });
+      const build = builds.find(({ buildNumber }) => buildNumber === buildRef);
+
+      if (build) {
+        return this._client().build(build.id)
+          .get();
+      }
+
+      throw new Error(
+        `Actor ${actorId} has no build tagged or numbered "${buildRef}". Please build the actor first or pick an existing build.`,
+      );
     },
     listActors(opts = {}) {
       return this._client().store()

--- a/components/apify_oauth/actions/run-actor/run-actor.mjs
+++ b/components/apify_oauth/actions/run-actor/run-actor.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "apify_oauth-run-actor",
-  version: "0.0.2",
+  version: "0.0.4",
   name,
   description,
   type,


### PR DESCRIPTION
## Why
- The Run Actor "Build" field only accepted build **tags** (e.g. `latest`). A build **number** like `0.1.2` was rejected by both the run-time validation and the schema resolution, even though Apify's run API accepts either.
- `latest` may not point to the newest or a working build (seen on `apify/facebook-posts-scraper`), so users had no way to target a specific version.
- The Build dropdown listed bare tag names with no version context.

Reported in Pipedream retest #612.

## What changed
**`apify.app.mjs`**
- `buildTag` dropdown now labels each tag with its build number (e.g. `latest (0.0.354)`) and returns `[]` before an Actor is selected. Build numbers can still be typed as free text, so the dropdown is a convenience, not a whitelist.
- Added `resolveBuildId(actorId, buildRef)`: resolves a build **tag or number** to a build id. Tries the tag map from `getActor` first, then falls back to matching `buildNumber` in `listBuilds`. Throws a single clear error when neither matches.
- `getBuild()` now delegates to `resolveBuildId` and just fetches the build.

**`actions/run-actor/run-actor.mjs`** (`0.0.7` → `0.0.12`)
- Replaced the inline tag-only validation block with one `resolveBuildId(actorId, buildTag)` call, so build numbers pass validation and the tag/number logic lives in one place.

## Testing
- `cd components/apify && npm run lint:fix` clean on both changed files (pre-existing `action-annotations` errors in `get-kvs-record`/`run-task` are unrelated and untouched).
- Build-list item shape (`buildNumber`, `buildNumberInt`, `id`, `status`) confirmed against the Apify REST API docs; the bundled `apify-client` type under-declares the list item, so we rely on the API response.
- `develop` has no `run-actor.test.mjs` (added by 669), so no test file added here to avoid an add/add conflict. Live smoke test done via `pd publish` + running the step in a workflow: tag (`latest`) and typed build number both load the input schema and run.

Closes [#670](https://github.com/apify/apify-integrations-backend/issues/670)


<img width="1065" height="165" alt="obrazek" src="https://github.com/user-attachments/assets/a9e05ca5-0594-4c18-96d9-23e77b9f0974" />
<img width="1079" height="594" alt="obrazek" src="https://github.com/user-attachments/assets/ae82dfe2-add3-45ce-b816-9d1f67a0eeab" />