### PR TITLE
fix: 676 ux dropdown messages

### DIFF
--- a/components/apify/README.md
+++ b/components/apify/README.md
@@ -14,4 +14,4 @@ The Apify API unleashes the power to automate web scraping, process data, and or
 
 **Real Estate Listings Aggregator**
 
-- Create a workflow where Apify actors periodically fetch the latest real estate listings from multiple websites. Process and normalize the data with Pipedream's code steps, then automatically update a Google Sheet that serves as a central repository for all listings, keeping potential buyers informed with the latest options.
+- Create a workflow where Apify Actors periodically fetch the latest real estate listings from multiple websites. Process and normalize the data with Pipedream's code steps, then automatically update a Google Sheet that serves as a central repository for all listings, keeping potential buyers informed with the latest options.

--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -107,7 +107,7 @@ export default {
     async getSchema(actorId, buildTag) {
       const build = await this.apify.getBuild(actorId, buildTag);
       if (!build) {
-        throw new Error(`No build found for actor ${actorId}`);
+        throw new Error(`No build found for Actor ${actorId}`);
       }
 
       // Case 1: schema is already an object
@@ -123,14 +123,14 @@ export default {
             : build.inputSchema;
         } catch (err) {
           throw new Error(
-            `Failed to parse inputSchema for actor ${actorId}: ${err.message}`,
+            `Failed to parse inputSchema for Actor ${actorId}: ${err.message}`,
           );
         }
       }
 
       // Case 3: no schema at all
       throw new Error(
-        `No input schema found for actor ${actorId}. Has it been built successfully?`,
+        `No input schema found for Actor ${actorId}. Has it been built successfully?`,
       );
     },
     async prepareData(data) {
@@ -303,7 +303,7 @@ export default {
       const taggedBuilds = actorDetails.taggedBuilds || {};
       if (!taggedBuilds[buildTag]) {
         throw new Error(
-          `Build with tag "${buildTag}" was not found for actor "${actorDetails.title || actorDetails.name}".`,
+          `Build with tag "${buildTag}" was not found for Actor "${actorDetails.title || actorDetails.name}".`,
         );
       }
     }

--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -54,10 +54,10 @@ export default {
       reloadProps: true,
       optional: true,
     },
-    runAsynchronously: {
+    waitForFinish: {
       type: "boolean",
-      label: "Run Asynchronously",
-      description: "Set to `true` to run the Actor asynchronously",
+      label: "Wait for Finish",
+      description: "If `true` (default), the step waits for the Actor run to finish and returns its output. If `false`, the step starts the run and returns immediately with the run details, without waiting.",
       reloadProps: true,
       default: true,
     },
@@ -246,7 +246,7 @@ export default {
       };
     }
 
-    if (!this.runAsynchronously) {
+    if (this.waitForFinish) {
       props.outputRecordKey = {
         type: "string",
         label: "Output Record Key",
@@ -273,7 +273,7 @@ export default {
       apify,
       actorId,
       buildTag,
-      runAsynchronously,
+      waitForFinish,
       outputRecordKey,
       timeout,
       memory,
@@ -347,8 +347,8 @@ export default {
 
     let run;
 
-    if (runAsynchronously) {
-      // async run
+    if (!waitForFinish) {
+      // async run — start and return immediately without waiting
       run = await apify.runActorAsynchronously({
         actorId,
         data: input,

--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -295,7 +295,7 @@ export default {
 
     if (!actorDetails.stats?.totalBuilds || actorDetails.stats.totalBuilds === 0) {
       throw new Error(
-        `Actor "${actorDetails.title || actorDetails.name}" has no builds. Please build it first before running.`,
+        `Actor "${actorDetails.title || actorDetails.name}" has no builds yet and can't be run until it's built. Open the Actor in Apify Console and build it (Source → Code → Build), or trigger a build via the Apify CLI/API, then run this step again.`,
       );
     }
 

--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -19,7 +19,7 @@ export default {
     actorSource: {
       type: "string",
       label: "Search Actors from",
-      description: "Where to search for Actors. Valid options are Store and Recently used Actors.",
+      description: "Where to search for Actors. Choose **Apify Store Actors** to browse the public [Apify Store](https://apify.com/store), or **Recently used Actors** to pick from Actors you've run before.",
       options: [
         {
           label: "Apify Store Actors",

--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -7,7 +7,7 @@ export default {
   key: "apify-run-actor",
   name: "Run Actor",
   description: "Performs an execution of a selected Actor in Apify. [See the documentation](https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -231,7 +231,7 @@ export default {
           .get();
       } else {
         throw new Error(
-          `Actor ${actorId} has no build tagged "${buildTag}". Please build the actor first.`,
+          `Actor ${actorId} has no build tagged "${buildTag}". Please build the Actor first.`,
         );
       }
     },

--- a/components/apify/apify.app.mjs
+++ b/components/apify/apify.app.mjs
@@ -29,7 +29,7 @@ export default {
     actorId: {
       type: "string",
       label: "Actor",
-      description: "Select the Actor, enter the Actor ID, or use a tilde-separated combination of the owner's username and the Actor name.",
+      description: "Select an Actor from the dropdown, enter an Actor ID, or use a tilde-separated owner/name identifier (e.g. `apify~web-scraper`). If the list is empty, switch \"Search Actors from\" to **Apify Store Actors**.",
       async options({
         page, actorSource,
       }) {
@@ -157,6 +157,17 @@ export default {
         offset: LIMIT * page,
         limit: LIMIT,
       });
+
+      if (actorSource !== "store" && page === 0 && items.length === 0) {
+        const { items: storeItems } = await this.listActors({
+          offset: 0,
+          limit: LIMIT,
+        });
+        return storeItems.map((actor) => ({
+          label: this.formatActorOrTaskLabel(actor),
+          value: actor.id,
+        }));
+      }
 
       return items.map((actor) => ({
         label: this.formatActorOrTaskLabel(actor),

--- a/components/apify/sources/new-finished-actor-run-instant/new-finished-actor-run-instant.mjs
+++ b/components/apify/sources/new-finished-actor-run-instant/new-finished-actor-run-instant.mjs
@@ -17,7 +17,7 @@ export default {
     actorSource: {
       type: "string",
       label: "Search Actors from",
-      description: "Where to search for Actors. Valid options are Store and Recently used Actors.",
+      description: "Where to search for Actors. Choose **Apify Store Actors** to browse the public [Apify Store](https://apify.com/store), or **Recently used Actors** to pick from Actors you've run before.",
       options: [
         {
           label: "Apify Store Actors",

--- a/components/apify_oauth/actions/run-actor/run-actor.mjs
+++ b/components/apify_oauth/actions/run-actor/run-actor.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "apify_oauth-run-actor",
-  version: "0.0.2",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/apify_oauth/sources/new-finished-actor-run-instant/new-finished-actor-run-instant.mjs
+++ b/components/apify_oauth/sources/new-finished-actor-run-instant/new-finished-actor-run-instant.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "apify_oauth-new-finished-actor-run-instant",
-  version: "0.0.2",
+  version: "0.0.4",
   name,
   description,
   type,


### PR DESCRIPTION
## Why
- The Actor dropdown was empty for brand new accounts (no recently used Actors), with no hint about switching to the Store. First run felt broken.
- "actor" vs "Actor" was capitalised inconsistently across labels, descriptions, and error messages.
- The "Wait for Finish" behaviour was labelled "Run Asynchronously", which was backwards and confusing.
- The no-build error just said "build it first" with no idea how.

Reported in Pipedream retest #612.

## What changed
**`apify.app.mjs`**
- `getActorOptions()` now falls back to Store Actors when "Recently used" comes back empty (first page only). Returning users keep their recent list; new users get a populated dropdown instead of a blank one.
- Tightened the `actorId` and `actorSource` descriptions so the Store option is discoverable, with an example ID and an empty-list hint.

**`actions/run-actor/run-actor.mjs`** (`0.0.7` -> `0.0.8`)
- **Breaking: renamed `runAsynchronously` -> `waitForFinish`.** This changes the prop key and inverts the boolean, and the default flips from "don't wait" to "wait". See the note below.
- Rewrote the no-build error to be actionable: it names the Actor and tells you to build it in Apify Console (Source > Code > Build) or via CLI/API before running.
- Capitalisation fixes in the error messages.

**`sources/new-finished-actor-run-instant`**, **`README.md`**
- Same `actorSource` description tweak and `actor` -> `Actor` capitalisation sweep.

## ⚠️ Breaking change (needs Apify sign-off)
The `runAsynchronously` -> `waitForFinish` rename affects existing deployed steps:
- The prop **key** changes, so saved values are dropped, and the step falls back to the new default.
- The boolean is **inverted**: old `runAsynchronously: true` (don't wait) maps to new `waitForFinish: false`.
- The **default flips**: old default was async (don't wait), new default is `waitForFinish: true` (wait for the run and return its output), matching Run Task.

Net effect: steps that relied on the old async default will start waiting for completion instead. `Output Record Key` is gated to the wait path, so it now shows by default.

## Testing
- `cd components/apify && npm run lint:fix` clean on the changed files (the pre-existing `action-annotations` errors in `get-kvs-record`/`run-task` are unrelated and untouched).
- Build/CLI terminology and "a build is required before running" confirmed against the Apify docs.
- Live smoke test via `pd publish` + running the step in a workflow: empty-account dropdown falls back to Store, "Wait for Finish" on returns output / off returns immediately, and a freshly created never-built Actor hits the new no-build message.

Closes [#676](https://github.com/apify/apify-integrations-backend/issues/676)

<img width="1064" height="135" alt="obrazek" src="https://github.com/user-attachments/assets/c558c92e-55fd-433c-add7-659b06d76e2f" />

