### PR TITLE
fix: 671 memory dropdown limits

### DIFF
--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -1,13 +1,16 @@
 /* eslint-disable no-unused-vars */
 import apify from "../../apify.app.mjs";
 import { parseObject } from "../../common/utils.mjs";
+import {
+  MEMORY_MBYTES_OPTIONS, MIN_MEMORY_MBYTES, MAX_MEMORY_MBYTES,
+} from "../../common/constants.mjs";
 import { WEBHOOK_EVENT_TYPES } from "@apify/consts";
 
 export default {
   key: "apify-run-actor",
   name: "Run Actor",
   description: "Performs an execution of a selected Actor in Apify. [See the documentation](https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -67,12 +70,6 @@ export default {
       description: "Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the default run configuration for the Actor.",
       optional: true,
     },
-    memory: {
-      type: "string",
-      label: "Memory (MB)",
-      description: "Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the default run configuration for the Actor.",
-      optional: true,
-    },
     maxItems: {
       type: "string",
       label: "Max Items",
@@ -104,12 +101,14 @@ export default {
         ? type
         : "string[]";
     },
-    async getSchema(actorId, buildTag) {
+    async getBuildOrThrow(actorId, buildTag) {
       const build = await this.apify.getBuild(actorId, buildTag);
       if (!build) {
         throw new Error(`No build found for actor ${actorId}`);
       }
-
+      return build;
+    },
+    extractInputSchema(build, actorId) {
       // Case 1: schema is already an object
       if (build.actorDefinition && build.actorDefinition.input) {
         return build.actorDefinition.input;
@@ -133,9 +132,42 @@ export default {
         `No input schema found for actor ${actorId}. Has it been built successfully?`,
       );
     },
-    async prepareData(data) {
+    async getSchema(actorId, buildTag) {
+      const build = await this.getBuildOrThrow(actorId, buildTag);
+      return this.extractInputSchema(build, actorId);
+    },
+    // Reads the Actor's declared memory limits from an already-fetched build,
+    // falling back to the platform limits (128 MB - 32 GB) when not declared.
+    getMemoryLimits(build) {
+      const {
+        minMemoryMbytes, maxMemoryMbytes,
+      } = build?.actorDefinition ?? {};
+      return {
+        min: Number.isInteger(minMemoryMbytes)
+          ? minMemoryMbytes
+          : MIN_MEMORY_MBYTES,
+        max: Number.isInteger(maxMemoryMbytes)
+          ? maxMemoryMbytes
+          : MAX_MEMORY_MBYTES,
+      };
+    },
+    buildMemoryProp({
+      min, max,
+    }) {
+      const options = MEMORY_MBYTES_OPTIONS.filter(({ value }) => value >= min && value <= max);
+      return {
+        type: "integer",
+        label: "Memory (MB)",
+        description: "Memory limit for the run, in megabytes. Must be a power of two between 128 MB and 32 GB. By default, the run uses the memory limit specified in the Actor's default run configuration.",
+        optional: true,
+        options: options.length
+          ? options
+          : MEMORY_MBYTES_OPTIONS,
+      };
+    },
+    async prepareData(data, schema) {
       const newData = {};
-      const { properties } = await this.getSchema(this.actorId, this.buildTag);
+      const { properties } = schema ?? await this.getSchema(this.actorId, this.buildTag);
 
       // Iterate over properties from the schema because newData might contain additional fields
       for (const [
@@ -185,8 +217,14 @@ export default {
   },
   async additionalProps() {
     const props = {};
+    let memoryLimits = {
+      min: MIN_MEMORY_MBYTES,
+      max: MAX_MEMORY_MBYTES,
+    };
     try {
-      const schema = await this.getSchema(this.actorId, this.buildTag);
+      const build = await this.getBuildOrThrow(this.actorId, this.buildTag);
+      memoryLimits = this.getMemoryLimits(build);
+      const schema = this.extractInputSchema(build, this.actorId);
       const {
         properties, required: requiredProps = [],
       } = schema;
@@ -245,6 +283,11 @@ export default {
         description: e.message || "Schema not available, showing fallback.",
       };
     }
+
+    // Ordered memory dropdown (128 MB - 32 GB), filtered to the Actor's
+    // declared min/max memory when present. Declared here (not in static props)
+    // so it can honor the per-Actor limits read from the fetched build.
+    props.memory = this.buildMemoryProp(memoryLimits);
 
     if (!this.runAsynchronously) {
       props.outputRecordKey = {
@@ -308,6 +351,26 @@ export default {
       }
     }
 
+    // Fetch the build once and reuse it for both the input schema and the
+    // Actor's declared memory limits (avoids adding a second build fetch).
+    const build = await this.getBuildOrThrow(actorId, buildTag);
+    const schema = this.extractInputSchema(build, actorId);
+    const {
+      min: minMemory, max: maxMemory,
+    } = this.getMemoryLimits(build);
+
+    // Defensive memory validation. The dropdown already filters valid options
+    // at configuration time; this guards against stale or injected values.
+    if (memory !== undefined && memory !== null && memory !== "") {
+      const mem = Number(memory);
+      const isValidStep = MEMORY_MBYTES_OPTIONS.some(({ value }) => value === mem);
+      if (!isValidStep || mem < minMemory || mem > maxMemory) {
+        throw new Error(
+          `Memory ${memory} MB is not valid for Actor "${actorDetails.title || actorDetails.name}". It must be a power of two between ${minMemory} and ${maxMemory} MB.`,
+        );
+      }
+    }
+
     // Prepare input
     // Use data (dynamic props from schema) if it has any keys,
     // otherwise fall back to this.properties (fallback object prop)
@@ -316,7 +379,7 @@ export default {
       : (this.properties
         ? parseObject(this.properties)
         : {});
-    const input = await this.prepareData(rawInput);
+    const input = await this.prepareData(rawInput, schema);
 
     // Build params safely
     const params = {

--- a/components/apify/actions/run-actor/run-actor.mjs
+++ b/components/apify/actions/run-actor/run-actor.mjs
@@ -186,10 +186,13 @@ export default {
     },
     prepareOptions(value) {
       if (value.enum && value.enumTitles) {
-        return value.enum.map((val, i) => ({
-          value: val,
-          label: value.enumTitles[i],
-        }));
+        // Drop options with an empty or null label
+        return value.enum
+          .map((val, i) => ({
+            value: val,
+            label: value.enumTitles[i],
+          }))
+          .filter(({ label }) => label !== "" && label != null);
       }
     },
     setValue(editor, item) {

--- a/components/apify/actions/run-task/run-task.mjs
+++ b/components/apify/actions/run-task/run-task.mjs
@@ -1,4 +1,5 @@
 import apify from "../../apify.app.mjs";
+import { MEMORY_MBYTES_OPTIONS } from "../../common/constants.mjs";
 import {
   ACTOR_JOB_STATUSES, ACTOR_JOB_TERMINAL_STATUSES, WEBHOOK_EVENT_TYPES,
 } from "@apify/consts";
@@ -7,7 +8,12 @@ export default {
   key: "apify-run-task",
   name: "Run Task",
   description: "Run a specific task and optionally wait for it's termination.",
-  version: "0.0.4",
+  version: "0.0.5",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
   type: "action",
   props: {
     apify,
@@ -42,9 +48,10 @@ export default {
     },
     memory: {
       type: "integer",
-      label: "Memory",
-      description: "Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the task settings.",
+      label: "Memory (MB)",
+      description: "Memory limit for the run, in megabytes. Must be a power of two between 128 MB and 32 GB. By default, the run uses the memory limit specified in the task settings.",
       optional: true,
+      options: MEMORY_MBYTES_OPTIONS,
     },
     build: {
       type: "string",

--- a/components/apify/actions/run-task/run-task.mjs
+++ b/components/apify/actions/run-task/run-task.mjs
@@ -8,7 +8,7 @@ export default {
   key: "apify-run-task",
   name: "Run Task",
   description: "Run a specific task and optionally wait for it's termination.",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apify/common/constants.mjs
+++ b/components/apify/common/constants.mjs
@@ -1,2 +1,25 @@
 export const WCC_ACTOR_ID = "aYG0l9s7dbB7j3gbS";
 export const LIMIT = 100;
+
+// Apify platform memory limits: memory must be a power of two, from 128 MB to 32 GB.
+// See https://docs.apify.com/actors/running/usage-and-resources#memory
+export const MIN_MEMORY_MBYTES = 128;
+export const MAX_MEMORY_MBYTES = 32768;
+
+function memoryLabel(mb) {
+  return mb >= 1024
+    ? `${mb / 1024} GB`
+    : `${mb} MB`;
+}
+
+// Ordered dropdown options for the run memory limit (128 MB -> 32 GB).
+export const MEMORY_MBYTES_OPTIONS = (() => {
+  const options = [];
+  for (let mb = MIN_MEMORY_MBYTES; mb <= MAX_MEMORY_MBYTES; mb *= 2) {
+    options.push({
+      label: memoryLabel(mb),
+      value: mb,
+    });
+  }
+  return options;
+})();

--- a/components/apify_oauth/actions/run-actor/run-actor.mjs
+++ b/components/apify_oauth/actions/run-actor/run-actor.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "apify_oauth-run-actor",
-  version: "0.0.2",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/apify_oauth/actions/run-task/run-task.mjs
+++ b/components/apify_oauth/actions/run-task/run-task.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "apify_oauth-run-task",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,


### PR DESCRIPTION
## Why
- Memory (MB) in Run Actor and Run Actor Task was a free numeric input. Nothing stopped invalid values: no power-of-two constraint, and the per-Actor minimum from Apify Console (e.g. `apify/facebook-posts-scraper` needs at least 1 GB) was never propagated.
- Run Task's memory field was labelled "Memory" instead of "Memory (MB)".
- While testing, selecting an Actor with a blank enum option (e.g. `countryCode` in Google Maps Scraper) broke the whole field reload with a generic "Unknown configuration error, refresh fields".

Reported in Pipedream retest #612.

## What changed
**`common/constants.mjs`**
- Added `MEMORY_MBYTES_OPTIONS` (ordered 128 MB to 32 GB ladder, integer MB values with human labels) plus `MIN_MEMORY_MBYTES` / `MAX_MEMORY_MBYTES`, shared by both actions.

**`actions/run-actor/run-actor.mjs`** (`0.0.7` -> `0.0.8`)
- `memory` is now an ordered dropdown instead of a free string field. It is declared in `additionalProps()` so it can honour the Actor's declared limits: the ladder is filtered to `[minMemoryMbytes, maxMemoryMbytes]` when the Actor sets them, and shows the full ladder otherwise.
- No extra API call. The build is fetched once and reused for both the input schema and the memory limits (`getBuildOrThrow` + `extractInputSchema` + `getMemoryLimits`), so this stays clear of the 642 fetch-count concerns.
- Added a defensive check in `run()` that rejects an out-of-range or non-power-of-two memory value with an error naming the Actor and the allowed range.
- Fixed `prepareOptions()` to drop options with an empty label. Some Actor schemas include a blank enum entry, which Pipedream rejects and which aborted the entire field reload. Pre-existing bug, reproduces on `develop`.

**`actions/run-task/run-task.mjs`** (`0.0.4` -> `0.0.6`)
- Relabelled "Memory" to "Memory (MB)" and gave it the same static ladder dropdown.
- Per-Actor limits are not applied here. Run Task starts from a `taskId`, so honouring the task's Actor min/max would need extra task to actId to build hops. Left as a best-effort follow-up to avoid added fetches (642).

## Testing
- `cd components/apify && npm run lint:fix` clean on the changed files. The pre-existing `action-annotations` errors in `run-task`/`get-kvs-record` are unrelated and untouched (owned by 672).
- Verified against Apify docs: memory must be a power of two from 128 MB to 32 GB, and per-Actor limits live on `build.actorDefinition.minMemoryMbytes` / `maxMemoryMbytes`.
- Live smoke test via `pd publish` and running the step in a workflow: the ladder renders in both actions, a selected value runs with that `memoryMbytes`, and Google Maps Scraper now loads its fields after the empty-label fix.

## Coordination
- `run-actor.mjs` collides with 669 / 670 / 675 / 676 (all sitting at `0.0.8`), and `run-task.mjs` with 672. Final versions and a `run-actor.test.mjs` union to be reconciled at merge.

Closes [#671](https://github.com/apify/apify-integrations-backend/issues/671)

<img width="1063" height="453" alt="obrazek" src="https://github.com/user-attachments/assets/477aa4d6-2e92-4434-9531-051e43bc3750" />