### PR TITLE
fix: 677 webhook lifecycle

### DIFF
--- a/components/apify/sources/common/base.mjs
+++ b/components/apify/sources/common/base.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import {
   WEBHOOK_EVENT_TYPE_GROUPS, WEBHOOK_EVENT_TYPES,
 } from "@apify/consts";
@@ -11,19 +12,62 @@ export default {
       type: "$.interface.http",
       customResponse: true,
     },
+    eventTypes: {
+      type: "string[]",
+      label: "Trigger on run states",
+      description: "Which terminal run states should fire this trigger. Leave empty to fire on all of them (the default).",
+      optional: true,
+      options: WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL.map((value) => {
+        const state = value.split(".").pop()
+          .replaceAll("_", " ")
+          .toLowerCase();
+        return {
+          label: state.charAt(0).toUpperCase() + state.slice(1),
+          value,
+        };
+      }),
+    },
+  },
+  methods: {
+    // SHA-256(endpoint + condition target) - stable across re-deploys so Apify
+    // reuses the same webhook instead of creating duplicates.
+    getIdempotencyKey() {
+      const target = Object.values(this.getCondition()).join(":");
+      return createHash("sha256")
+        .update(`${this.http.endpoint}:${target}`)
+        .digest("hex");
+    },
   },
   hooks: {
     async activate() {
+      // Whitelist terminal states only; fall back to all when none are valid.
+      const selected = (this.eventTypes ?? [])
+        .filter((type) => WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL.includes(type));
+
       const response = await this.apify.createHook({
         requestUrl: this.http.endpoint,
-        eventTypes: WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL,
+        eventTypes: selected.length
+          ? selected
+          : WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL,
         condition: this.getCondition(),
+        idempotencyKey: this.getIdempotencyKey(),
       });
       this.db.set("webhookId", response.id);
     },
     async deactivate() {
       const webhookId = this.db.get("webhookId");
-      await this.apify.deleteHook(webhookId);
+      if (!webhookId) {
+        return;
+      }
+
+      // Tolerate already-deleted webhooks so deactivate→activate cycles don't break.
+      try {
+        await this.apify.deleteHook(webhookId);
+      } catch (error) {
+        console.warn(`Failed to delete Apify webhook ${webhookId} (it may already be removed): ${error.message}`);
+      } finally {
+        this.db.set("webhookId", null);
+      }
     },
   },
   async run({ body }) {
@@ -35,7 +79,7 @@ export default {
       summary: body.eventType === WEBHOOK_EVENT_TYPES.TEST
         ? "Webhook test has successfully triggered!"
         : this.getSummary(body),
-      id: body.eventData.actorRunId || `${body.userId}-${body.createAt}`,
+      id: body.eventData.actorRunId || `${body.userId}-${body.createdAt}`,
       ts: Date.parse(body.createdAt),
     });
   },

--- a/components/apify/sources/new-finished-actor-run-instant/new-finished-actor-run-instant.mjs
+++ b/components/apify/sources/new-finished-actor-run-instant/new-finished-actor-run-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "apify-new-finished-actor-run-instant",
   name: "New Finished Actor Run (Instant)",
   description: "Emit new event when a selected Actor is run and finishes.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/apify/sources/new-finished-task-run-instant/new-finished-task-run-instant.mjs
+++ b/components/apify/sources/new-finished-task-run-instant/new-finished-task-run-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "apify-new-finished-task-run-instant",
   name: "New Finished Task Run (Instant)",
   description: "Emit new event when a selected task is run and finishes.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## Why
Two webhook-source behaviors were unvalidated in the retest and could cause silent failures, plus a UX parity gap:
- **Orphaned / duplicate webhooks.** Re-deploying a trigger could leave stale webhooks on the Apify side, and removing a trigger didn't reliably clean up the webhook — it became a leftover in the Actor's webhook list.
- **Unguarded webhook deletion.** `deactivate()` called `deleteHook` with no error handling, so an already-deleted webhook (e.g. removed manually in the Apify Console) would throw and could abort a re-deploy's deactivate→activate cycle, leaving the source with no webhook.
- **Broken fallback dedupe id.** A typo (`body.createAt`) produced `<userId>-undefined` as the event id whenever `actorRunId` was absent.
- **No way to choose which run states fire the trigger.** Both triggers fired on all four terminal states (Succeeded / Failed / Timed out / Aborted) with no option to narrow it — unlike Make / Zapier / n8n. Reported alongside Pipedream retest 612 ([677](https://github.com/apify/apify-integrations-backend/issues/677) verification).

## What changed
**`sources/common/base.mjs`** (shared by both finished-run triggers)
- **Bug C — idempotent activation.** `activate()` now sends an `idempotencyKey` so re-deploying the source reuses the same Apify webhook instead of creating a duplicate. The key is `SHA256(requestUrl + condition target [Actor/Task id])` — the **same formula as the Apify Power Automate connector**, keeping the two integrations consistent. Verified `idempotencyKey` is supported by `apify-client` (`WebhookUpdateData`) and the REST API (`POST /webhooks`), and its "return existing instead of duplicating" semantics against the Apify docs.
- **Bug A — guarded `deactivate()`.** Returns early if no webhook id is stored, wraps `deleteHook` in try/catch with a warning, and clears the stored id in `finally`. A webhook that was already removed no longer throws or breaks re-deploy.
- **Bug B — fallback dedupe id.** `body.createAt` → `body.createdAt`.
- **Enhancement — selectable trigger event types.** New optional `eventTypes` multi-select (the four terminal states, labels derived from `@apify/consts`). **Leaving it empty fires on all four** (previous behavior), so it's non-breaking.

**`sources/new-finished-actor-run-instant`** (`0.0.8` → `0.0.9`) and **`sources/new-finished-task-run-instant`** (`0.0.7` → `0.0.8`)
- Version bumps to ship the shared `base.mjs` changes.

## Testing
- `cd components/apify && npm run lint:fix` clean on the changed files. The pre-existing `action-annotations` errors in `run-task` / `get-kvs-record` are unrelated and untouched (owned by 672).
- Logic proven with a local `node --test` harness (sources have no test suite on `develop`): idempotency key shape/stability, guarded deactivate (throw swallowed, id cleared), `createdAt` fallback, and `eventTypes` defaulting to all four when empty.
- Verified `idempotencyKey` support + semantics against the Apify webhook API docs.
- **Live smoke test** (`pd dev` / deployed workflow): disabling a trigger removes the webhook from the Actor; deleting the webhook in the Console then disabling + re-enabling re-creates it (no crash); and the trigger fires only for the selected run state(s).

## Coordination
- `[677](https://github.com/apify/apify-integrations-backend/issues/677)` is isolated — it only touches `sources/common/base.mjs` and the two source components, which no other open branch edits. No cross-branch conflict expected.
- Note: because the idempotency key is stable per (endpoint, target), a *changed* state selection only propagates if the re-deploy deletes the old hook first — confirmed OK for the disable/enable cycle.

Closes [677](https://github.com/apify/apify-integrations-backend/issues/677)